### PR TITLE
feat: 更新获取用户偏好标签文章的方法

### DIFF
--- a/WebApplication3/Biz/WorkBiz.cs
+++ b/WebApplication3/Biz/WorkBiz.cs
@@ -46,7 +46,7 @@ namespace WebApplication3.Biz
             }
         }
 
-        public List<Work> GetArticlesByUserFavoriteTags(long userCode, int page, int pageSize)
+        public (List<Work> Data, long Total) GetArticlesByUserFavoriteTags(long userCode, int page, int pageSize)
         {
             return workDao.GetArticlesByUserFavoriteTags(userCode, page, pageSize);
         }

--- a/WebApplication3/Controllers/WorkController.cs
+++ b/WebApplication3/Controllers/WorkController.cs
@@ -296,13 +296,15 @@ namespace WebApplication3.Controllers
 
             // 获取用户偏好的文章
             var workBiz = new WorkBiz();
-            var workList = workBiz.GetArticlesByUserFavoriteTags(userCode, page, pageSize);
-            if (workList == null) throw new CustomException("未查询到数据！");
+            var work = workBiz.GetArticlesByUserFavoriteTags(userCode, page, pageSize);
+            if (work.Total == 0) throw new CustomException("未查询到数据！");
+            if (work.Data == null) throw new CustomException("未查询到数据！");
 
             // 构造精简响应数据
             dic.Add("status", 200);
             dic.Add("message", "成功");
-            dic.Add("data", workList.Select(a => new
+            dic.Add("Total", work.Total);
+            dic.Add("data", work.Data.Select(a => new
             {
                 a.Code,
                 a.Tags,

--- a/WebApplication3/Dao/WorkDao.cs
+++ b/WebApplication3/Dao/WorkDao.cs
@@ -24,18 +24,22 @@ namespace WebApplication3.Dao
                 .First();
         }
 
-        public List<Work> GetArticlesByUserFavoriteTags(long userCode, int page, int pageSize)
+        public (List<Work> Data, long Total) GetArticlesByUserFavoriteTags(long userCode, int page, int pageSize)
         {
-            return FreeSqlHelper.Instance.Select<Work>()
+            var sql = FreeSqlHelper.Instance.Select<Work>()
                 .Where(w => FreeSqlHelper.Instance.Select<UserFavoriteTag>()
                                 .Where(uf => uf.UserCode == userCode)
                                 .Any(uf => uf.TagCode == w.Code) &&
                             !FreeSqlHelper.Instance.Select<UserDislikedTag>()
                                 .Where(ud => ud.UserCode == userCode)
                                 .Any(ud => ud.TagCode == w.Code))
-                .OrderByDescending(d => d.CreatedAt)
+                .OrderByDescending(d => d.CreatedAt);
+                
+             var list = sql
                 .Page(page, pageSize)
                 .ToList();
+            long count = sql.Count();
+            return (list, count);
         }
 
         public List<Work> GetWorkByCollectionCode(long collectionCode)


### PR DESCRIPTION
feat: 更新获取用户偏好标签文章的方法

在 `WorkBiz.cs` 中，将 `GetArticlesByUserFavoriteTags` 方法的返回类型更改为 `(List<Work> Data, long Total)`，并调整了方法内部逻辑以返回文章列表和总数。

在 `WorkController.cs` 中，修改了调用 `GetArticlesByUserFavoriteTags` 方法的方式，以适应新的返回类型，并增加了对返回数据的检查。

在 `WorkDao.cs` 中，更新了 `GetArticlesByUserFavoriteTags` 方法的实现，使用新的 SQL 查询逻辑获取文章列表和总数，并返回一个包含这两个值的元组。